### PR TITLE
Reorganize key names

### DIFF
--- a/js/admin/src/main.js
+++ b/js/admin/src/main.js
@@ -6,7 +6,7 @@ app.initializers.add('flarum-sticky', () => {
   extend(PermissionGrid.prototype, 'moderateItems', items => {
     items.add('sticky', {
       icon: 'thumb-tack',
-      label: 'Sticky discussions',
+      label: app.translator.trans('flarum-sticky.admin.permissions.sticky_discussions_label'),
       permission: 'discussion.sticky'
     }, 95);
   });

--- a/js/forum/src/addStickyBadge.js
+++ b/js/forum/src/addStickyBadge.js
@@ -7,7 +7,7 @@ export default function addStickyBadge() {
     if (this.isSticky()) {
       badges.add('sticky', Badge.component({
         type: 'sticky',
-        label: app.translator.trans('flarum-sticky.forum.stickied'),
+        label: app.translator.trans('flarum-sticky.forum.badge.sticky_tooltip'),
         icon: 'thumb-tack'
       }), 10);
     }

--- a/js/forum/src/addStickyControl.js
+++ b/js/forum/src/addStickyControl.js
@@ -7,7 +7,7 @@ export default function addStickyControl() {
   extend(DiscussionControls, 'moderationControls', function(items, discussion) {
     if (discussion.canSticky()) {
       items.add('sticky', Button.component({
-        children: app.translator.trans(discussion.isSticky() ? 'flarum-sticky.forum.unsticky' : 'flarum-sticky.forum.sticky'),
+        children: app.translator.trans(discussion.isSticky() ? 'flarum-sticky.forum.discussion_controls.unsticky_button' : 'flarum-sticky.forum.discussion_controls.sticky_button'),
         icon: 'thumb-tack',
         onclick: this.stickyAction.bind(discussion)
       }));

--- a/js/forum/src/components/DiscussionStickiedNotification.js
+++ b/js/forum/src/components/DiscussionStickiedNotification.js
@@ -12,6 +12,6 @@ export default class DiscussionStickiedNotification extends Notification {
   }
 
   content() {
-    return app.translator.trans('flarum-sticky.forum.discussion_stickied_notification', {user: this.props.notification.sender()});
+    return '{username} stickied';
   }
 }

--- a/js/forum/src/components/DiscussionStickiedPost.js
+++ b/js/forum/src/components/DiscussionStickiedPost.js
@@ -7,7 +7,7 @@ export default class DiscussionStickiedPost extends EventPost {
 
   descriptionKey() {
     return this.props.post.content().sticky
-      ? 'flarum-sticky.forum.discussion_stickied_post'
-      : 'flarum-sticky.forum.discussion_unstickied_post';
+      ? 'flarum-sticky.forum.post_stream.discussion_stickied_text'
+      : 'flarum-sticky.forum.post_stream.discussion_unstickied_text';
   }
 }


### PR DESCRIPTION
See [flarum/core #265](https://github.com/flarum/core/issues/265).
- Adjusts key names to three-tier namespacing.
- Extracts previously unextracted strings.
