### PR TITLE
Add is_sticky, last_posted_at index

### DIFF
--- a/migrations/2021_01_13_000000_add_discussion_last_posted_at_indices.php
+++ b/migrations/2021_01_13_000000_add_discussion_last_posted_at_indices.php
@@ -1,0 +1,25 @@
+<?php
+
+/*
+ * This file is part of Flarum.
+ *
+ * For detailed copyright and license information, please view the
+ * LICENSE file that was distributed with this source code.
+ */
+
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Schema\Builder;
+
+return [
+    'up' => function (Builder $schema) {
+        $schema->table('discussions', function (Blueprint $table) {
+            $table->index(['is_sticky', 'last_posted_at']);
+        });
+    },
+
+    'down' => function (Builder $schema) {
+        $schema->table('discussions', function (Blueprint $table) {
+            $table->dropIndex(['is_sticky', 'last_posted_at']);
+        });
+    }
+];


### PR DESCRIPTION
Fixes flarum/core#2542

This PR introduces an additional index `[is_sticky, last_posted_at]` to the `discussions` table.  giffgaff discovered that when viewing discussions in a tag with a large number of discussions (approx 1.4M in this case), performance was poor when using the default sort criteria (sort by latest).

On investigation, the `order by` here appeared to be the culprit. https://github.com/flarum/sticky/blob/57cf21950bc651f085e6c9427e7408df487ea4b4/src/Listener/PinStickiedDiscussionsToTop.php#L56

Inspecting the resulting SQL, we have ```order by `is_sticky` desc, `last_posted_at` desc```

By adding this index, response times reduced as follows:

Before
![image](https://user-images.githubusercontent.com/16573496/104439343-e6248b80-5588-11eb-8c5e-1b0a524a6d0f.png)

After
![image](https://user-images.githubusercontent.com/16573496/104439373-efadf380-5588-11eb-9d0b-7dd91e0ed54c.png)
