### PR TITLE
Add class to sticky discussions

### DIFF
--- a/js/src/forum/addStickyClass.js
+++ b/js/src/forum/addStickyClass.js
@@ -1,0 +1,12 @@
+import { extend } from 'flarum/common/extend';
+import classList from 'flarum/common/utils/classList';
+
+import DiscussionListItem from 'flarum/forum/components/DiscussionListItem';
+
+export default function addStickyClass() {
+  extend(DiscussionListItem.prototype, 'elementAttrs', function (attrs) {
+    if (this.attrs.discussion.isSticky()) {
+      attrs.className = classList(attrs.className, 'DiscussionListItem--sticky');
+    }
+  });
+}

--- a/js/src/forum/index.js
+++ b/js/src/forum/index.js
@@ -6,6 +6,7 @@ import DiscussionStickiedPost from './components/DiscussionStickiedPost';
 import addStickyBadge from './addStickyBadge';
 import addStickyControl from './addStickyControl';
 import addStickyExcerpt from './addStickyExcerpt';
+import addStickyClass from './addStickyClass';
 
 app.initializers.add('flarum-sticky', () => {
   app.postComponents.discussionStickied = DiscussionStickiedPost;
@@ -16,5 +17,6 @@ app.initializers.add('flarum-sticky', () => {
   addStickyBadge();
   addStickyControl();
   addStickyExcerpt();
+  addStickyClass();
 });
 


### PR DESCRIPTION
Progresses https://github.com/flarum/core/issues/2128

- Adds `DiscussionListItem--sticky` class to discussions in the Discussion List

I found it impossible to set the `bodyClass` in DiscussionPage. This is set to the `#app` element before any discussion is loaded, and changes made to it after-the-fact don't have any effect.

Is there any way to do this other than jQuery/DOM manipulation that you can think of?

My best approach:

```js
document.getElemendById('app').classList.add('App--discussion-sticky')
```